### PR TITLE
Simple typo in jukebox-include-song-retrieve.sample

### DIFF
--- a/jukebox-include-song-retrieve.sample
+++ b/jukebox-include-song-retrieve.sample
@@ -3,7 +3,7 @@
   "songTitle": "Get Lucky",
   "duration": "6:07",
   "artist": {
-    "artistId": "110e8300-e32b-41d4-a716-664400445500"
+    "artistId": "110e8300-e32b-41d4-a716-664400445500",
     "artistName": "Daft Punk",
     "imageURL": "http://travelhymns.com/wp-content/uploads/2013/06/random-access-memories1.jpg"
   },


### PR DESCRIPTION
Discovered a missing comma while trying to implement a parser to conform to the RAML spec.
